### PR TITLE
Bugfix: Fixed calls to CreateMover causing crashes

### DIFF
--- a/ElvUI_AuraBarsMovers/ElvUI_AuraBarsMovers.lua
+++ b/ElvUI_AuraBarsMovers/ElvUI_AuraBarsMovers.lua
@@ -42,7 +42,7 @@ function ABM:TargetABmove()
 	auraBar:Point("BOTTOM", holder, "TOP", 0, 0)
 	auraBar.Holder = holder
 
-	E:CreateMover(auraBar.Holder, "ElvUF_TargetAuraMover", L["Target Aura Bars"], nil, nil, nil, "ALL,SOLO", "elvuiPlugins,auraBarMovers")
+	E:CreateMover(auraBar.Holder, "ElvUF_TargetAuraMover", L["Target Aura Bars"], nil, nil, nil, "ALL,SOLO", nil, "elvuiPlugins,auraBarMovers")
 	UF:CreateAndUpdateUF("target")
 end
 
@@ -54,7 +54,7 @@ function ABM:FocusABmove()
 	auraBar:Point("BOTTOM", holder, "TOP", 0, 0)
 	auraBar.Holder = holder
 
-	E:CreateMover(auraBar.Holder, "ElvUF_FocusAuraMover", L["Focus Aura Bars"], nil, nil, nil, "ALL,SOLO", "elvuiPlugins,auraBarMovers")
+	E:CreateMover(auraBar.Holder, "ElvUF_FocusAuraMover", L["Focus Aura Bars"], nil, nil, nil, "ALL,SOLO", nil, "elvuiPlugins,auraBarMovers")
 	UF:CreateAndUpdateUF("focus")
 end
 
@@ -66,7 +66,7 @@ function ABM:PetABmove()
 	auraBar:Point("BOTTOM", holder, "TOP", 0, 0)
 	auraBar.Holder = holder
 
-	E:CreateMover(auraBar.Holder, "ElvUF_PetAuraMover", L["Pet Aura Bars"], nil, nil, nil, "ALL,SOLO", "elvuiPlugins,auraBarMovers")
+	E:CreateMover(auraBar.Holder, "ElvUF_PetAuraMover", L["Pet Aura Bars"], nil, nil, nil, "ALL,SOLO", nil, "elvuiPlugins,auraBarMovers")
 	UF:CreateAndUpdateUF("pet")
 end
 


### PR DESCRIPTION
Discussed here:
https://github.com/ElvUI-TBC/ElvUI/issues/455

This addon was sending the wrong parameters to CreateMover, missing
the 8th parameter (nil) in 3 of the 4 calls to it. That was causing
the GUI to crash/freeze whenever you received or tried to switch
to any ElvUI profile with aurabar mover enabled.